### PR TITLE
Add service definitions to set and get Behavior parameters

### DIFF
--- a/moveit_studio_msgs/moveit_studio_sdk_msgs/CMakeLists.txt
+++ b/moveit_studio_msgs/moveit_studio_sdk_msgs/CMakeLists.txt
@@ -24,6 +24,8 @@ set(msg_files
 set(srv_files
   "srv/CancelObjective.srv"
   "srv/ExecuteObjective.srv"
+  "srv/RetrieveBehaviorParameter.srv"
+  "srv/SetBehaviorParameter.srv"
 )
 
 set(action_files

--- a/moveit_studio_msgs/moveit_studio_sdk_msgs/srv/RetrieveBehaviorParameter.srv
+++ b/moveit_studio_msgs/moveit_studio_sdk_msgs/srv/RetrieveBehaviorParameter.srv
@@ -1,0 +1,5 @@
+# Service which retrieves user input for behavior parameters
+string parameter_name
+---
+moveit_studio_sdk_msgs/RequestStatus status
+moveit_studio_sdk_msgs/BehaviorParameter parameter

--- a/moveit_studio_msgs/moveit_studio_sdk_msgs/srv/SetBehaviorParameter.srv
+++ b/moveit_studio_msgs/moveit_studio_sdk_msgs/srv/SetBehaviorParameter.srv
@@ -1,0 +1,4 @@
+# Service which sets user input for behavior parameters
+moveit_studio_sdk_msgs/BehaviorParameter parameter
+---
+moveit_studio_sdk_msgs/RequestStatus status


### PR DESCRIPTION
This PR adds `SetBehaviorParameter` and `RetrieveBehaviorParameter` service definitions to the `moveit_studio_sdk_msgs` package.

(actually, the `RetrieveBehaviorParameter` definition was moved over from the private repo)