### PR TITLE
Point indices are signed integers.

### DIFF
--- a/moveit_studio_msgs/moveit_studio_vision_msgs/msg/Mask3D.msg
+++ b/moveit_studio_msgs/moveit_studio_vision_msgs/msg/Mask3D.msg
@@ -7,7 +7,7 @@
 std_msgs/Header header
 
 # Indices of the points in the segmented point cloud that belong to this mask.
-uint32[] point_indices
+int32[] point_indices
 
 # Classification hypotheses sorted from most to least likely.
 # If the mask was not classified, this field is empty.


### PR DESCRIPTION
This just makes interfacing with PCL seamless. We can straight assign PCL indices to the message. Otherwise, we have to loop over the indices casting the value.