### PR TITLE
Add object_type and color to GraspableObject.msg

### DIFF
--- a/moveit_studio_msgs/moveit_studio_vision_msgs/CMakeLists.txt
+++ b/moveit_studio_msgs/moveit_studio_vision_msgs/CMakeLists.txt
@@ -9,6 +9,7 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(geometry_msgs REQUIRED)
+find_package(moveit_msgs REQUIRED)
 find_package(moveit_studio_sdk_msgs REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(sensor_msgs REQUIRED)
@@ -37,6 +38,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   DEPENDENCIES
     builtin_interfaces  
     geometry_msgs
+    moveit_msgs
     moveit_studio_sdk_msgs
     sensor_msgs
     shape_msgs

--- a/moveit_studio_msgs/moveit_studio_vision_msgs/msg/GraspableObject.msg
+++ b/moveit_studio_msgs/moveit_studio_vision_msgs/msg/GraspableObject.msg
@@ -8,6 +8,9 @@ std_msgs/Header header
 # This is what is used as the `child_frame_id` when creating a TF to this object.
 string id
 
+# Optional class or name of the object type.
+string object_type
+
 # The pose of the object relative to the frame specified in the header. This is 
 # used to create the transform to the object, from which all subframe poses are relative to.
 geometry_msgs/Pose pose

--- a/moveit_studio_msgs/moveit_studio_vision_msgs/msg/GraspableObject.msg
+++ b/moveit_studio_msgs/moveit_studio_vision_msgs/msg/GraspableObject.msg
@@ -34,3 +34,6 @@ geometry_msgs/Pose[] mesh_poses
 
 # Subframes. These correspond to affordances and their poses (relative to the object's pose).
 ObjectSubframe[] subframes
+
+# Optional color of the object.
+moveit_msgs/ObjectColor object_color

--- a/moveit_studio_msgs/moveit_studio_vision_msgs/package.xml
+++ b/moveit_studio_msgs/moveit_studio_vision_msgs/package.xml
@@ -13,6 +13,7 @@
 
   <depend>builtin_interfaces</depend>
   <depend>geometry_msgs</depend>
+  <depend>moveit_msgs</depend>
   <depend>moveit_studio_sdk_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>shape_msgs</depend>


### PR DESCRIPTION
For the Task and Motion Planning project we need the ability to specify the `type` of object we are working with in the scene. For example most of the GraspableObjects will be CTB's (cargo transfer bags) but we need to identify their contents (like food vs equipment). This PR adds an option field to the message to hold that information and it's planned to be copied to the [CollisionObject.msg](http://docs.ros.org/en/noetic/api/moveit_msgs/html/msg/CollisionObject.html) `object_recognition_msgs/ObjectType type.key` variable when this message is converted to a collision object in the planning scene.

To visually see the different CTB object types in the planning scene I have also added the ability for users to set the `object_color` in this message. I will add the feature of copying over the color value to the `ModifyObjectInPlanningScene` Behavior.