### PR TITLE
Add valid_classes field.

### DIFF
--- a/moveit_studio_msgs/moveit_studio_vision_msgs/action/GetMasks2D.action
+++ b/moveit_studio_msgs/moveit_studio_vision_msgs/action/GetMasks2D.action
@@ -3,6 +3,12 @@
 # Image to segment.
 sensor_msgs/Image image
 
+# Text strings describing the objects to segment. Only masks of objects matching the strings
+# will be returned.
+# If the model has a finite vocabulary, each string is an existing class label, e.g. button, door handle.
+# If the model is open-vocabulary, each string is a freeform description, e.g. flat red button, door with black handle.
+string[] valid_classes
+
 # Segmentation parameters. They are stored as key-value pairs because they are 
 # specific to the segmentation model being run by the action server.
 moveit_studio_sdk_msgs/BehaviorParameter[] parameters


### PR DESCRIPTION
The goal of this change is being able to narrow down the masks to those we want. For Mask R-CNN, the valid classes match the class string in the model vocabulary. For SAM+CLIP, they are freeform text strings that are matched against the image patch CLIP embeddings to create the segmentation prior for SAM.