### PR TITLE
Add point queries and clean up GetMasks2D message.

### DIFF
--- a/moveit_studio_msgs/moveit_studio_vision_msgs/action/GetMasks2D.action
+++ b/moveit_studio_msgs/moveit_studio_vision_msgs/action/GetMasks2D.action
@@ -3,11 +3,18 @@
 # Image to segment.
 sensor_msgs/Image image
 
-# Text strings describing the objects to segment. Only masks of objects matching the strings
-# will be returned.
+# Text strings describing the objects to segment. Only masks of objects matching at least one string 
+# will be returned. If no string is passed, this filter is disabled.
 # If the model has a finite vocabulary, each string is an existing class label, e.g. button, door handle.
-# If the model is open-vocabulary, each string is a freeform description, e.g. flat red button, door with black handle.
+# If the model is open-vocabulary, each string is a freeform description, e.g. flat red button, door with
+# black handle.
 string[] valid_classes
+
+# Image points indicating the objects to segment. Only masks containing at least one point will be returned.
+# If no points are passed, this filter is disabled.
+# Points are expressed in a frame with origin at the top-left corner of the image, with its x axis pointing
+# right, and its y axis point down. The z coordinate is not used.
+geometry_msgs/Point32[] valid_points
 
 # Segmentation parameters. They are stored as key-value pairs because they are 
 # specific to the segmentation model being run by the action server.


### PR DESCRIPTION
This PR adds point queries to the segmentation action goal. This is compatible with the interface of the upcoming Superseg model. Other segmentation action servers should also enforce that only masks containing at least one point are returned. 