### PR TITLE
Add has_ik_solver field to PlanningGroup msg

### DIFF
--- a/moveit_studio_msgs/moveit_studio_agent_msgs/msg/PlanningGroup.msg
+++ b/moveit_studio_msgs/moveit_studio_agent_msgs/msg/PlanningGroup.msg
@@ -1,6 +1,10 @@
 # Name of the planning group, as defined in the SRDF.
 string name
 
+# Indicates if an IK solver is defined for this group
+# and thus, if it can be used by servo
+bool has_ik_solver
+
 # Base frame of the planning group.
 # Only filled in if the group has a kinematics solver.
 string base_frame


### PR DESCRIPTION
Required by https://github.com/PickNikRobotics/moveit_studio/pull/6002 to make sure the servo planning group selection dropdown menu doesn't contain invalid planning groups.
See https://github.com/PickNikRobotics/moveit_studio/pull/6002#discussion_r1482647281 for more context.