### PR TITLE
Change PCD message to byte array to avoid null terminator issue

### DIFF
--- a/moveit_studio_msgs/moveit_studio_vision_msgs/msg/PointCloudPCD.msg
+++ b/moveit_studio_msgs/moveit_studio_vision_msgs/msg/PointCloudPCD.msg
@@ -1,5 +1,5 @@
 # Request identifier
 string uuid
 
-# A pointcloud in ASCII PCD (Point Cloud Data) format
-string point_cloud_data
+# A pointcloud in Binary Compressed PCD (Point Cloud Data) format
+uint8[] point_cloud_data


### PR DESCRIPTION
If you load binary data into a string in ROS, it loses everything after a null character. That's a sad and weird issue, since C++ strings don't have that issue, but the workaround here is to use a vector of bytes instead.

This is a prerequisite to PickNikRobotics/moveit_studio#6771.