### PR TITLE
Bump moveit_studio_sdk to version `3.0.0`

### DIFF
--- a/moveit_studio_msgs/moveit_studio_agent_msgs/package.xml
+++ b/moveit_studio_msgs/moveit_studio_agent_msgs/package.xml
@@ -1,6 +1,6 @@
 <package format="3">
   <name>moveit_studio_agent_msgs</name>
-  <version>2.13.0</version>
+  <version>3.0.0</version>
   <description>Messages, services, and actions used by the MoveIt Pro Agent</description>
   <author email="joseph.schornak@picknik.ai">Joe Schornak</author>
   <maintainer email="joseph.schornak@picknik.ai">Joe Schornak</maintainer>

--- a/moveit_studio_msgs/moveit_studio_msgs/package.xml
+++ b/moveit_studio_msgs/moveit_studio_msgs/package.xml
@@ -1,6 +1,6 @@
 <package format="3">
   <name>moveit_studio_msgs</name>
-  <version>2.13.0</version>
+  <version>3.0.0</version>
   <description>Metapackage for MoveIt Pro message definitions</description>
   <author email="joseph.schornak@picknik.ai">Joe Schornak</author>
   <maintainer email="joseph.schornak@picknik.ai">Joe Schornak</maintainer>

--- a/moveit_studio_msgs/moveit_studio_sdk_msgs/package.xml
+++ b/moveit_studio_msgs/moveit_studio_sdk_msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>moveit_studio_sdk_msgs</name>
-  <version>2.13.0</version>
+  <version>3.0.0</version>
   <description>Messages and services used by the MoveIt Pro SDK</description>
   <author email="ashton.larkin@picknik.ai">Ashton Larkin</author>
   <maintainer email="ashton.larkin@picknik.ai">Ashton Larkin</maintainer>

--- a/moveit_studio_msgs/moveit_studio_vision_msgs/package.xml
+++ b/moveit_studio_msgs/moveit_studio_vision_msgs/package.xml
@@ -1,6 +1,6 @@
 <package format="3">
   <name>moveit_studio_vision_msgs</name>
-  <version>2.13.0</version>
+  <version>3.0.0</version>
   <description>Messages, services, and actions used by MoveIt Pro vision capabilities.</description>
   <author email="sebastian.castro@picknik.ai">Sebastian Castro</author>
   <maintainer email="sebastian.castro@picknik.ai">Sebastian Castro</maintainer>

--- a/moveit_studio_py/package.xml
+++ b/moveit_studio_py/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>moveit_studio_py</name>
-  <version>2.13.0</version>
+  <version>3.0.0</version>
   <description>Python API for MoveIt Pro SDK.</description>
   <author email="ashton.larkin@picknik.ai">Ashton Larkin</author>
   <maintainer email="ashton.larkin@picknik.ai">Ashton Larkin</maintainer>

--- a/moveit_studio_py/setup.py
+++ b/moveit_studio_py/setup.py
@@ -4,7 +4,7 @@ package_name = "moveit_studio_py"
 
 setup(
     name=package_name,
-    version="2.12.0",
+    version="3.0.0",
     packages=find_packages(),
     zip_safe=True,
     maintainer="Ashton Larkin",


### PR DESCRIPTION
This PR contains the needed changes to bump the version to the next minor release to main :eye: Please review that the changes are correct as the replacement of the version numbers is done automatically and can be wrong.
