### PR TITLE
move moveit_pro_controller_msgs into the sdk repo

### DIFF
--- a/moveit_studio_msgs/moveit_pro_controllers_msgs/CMakeLists.txt
+++ b/moveit_studio_msgs/moveit_pro_controllers_msgs/CMakeLists.txt
@@ -1,0 +1,32 @@
+cmake_minimum_required(VERSION 3.8)
+project(moveit_pro_controllers_msgs)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(action_msgs REQUIRED)
+find_package(builtin_interfaces REQUIRED)
+find_package(control_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(trajectory_msgs REQUIRED)
+
+find_package(rosidl_default_generators REQUIRED)
+
+rosidl_generate_interfaces(
+  ${PROJECT_NAME}
+  "action/FollowJointTrajectoryWithAdmittance.action"
+  "msg/AdmittanceParameters.msg"
+  "msg/CartesianSelectionVector.msg"
+  "msg/VelocityForceCommand.msg"
+  "srv/ConfigureVelocityForceController.srv"
+  DEPENDENCIES
+  action_msgs
+  builtin_interfaces
+  control_msgs
+  geometry_msgs
+  std_msgs
+  trajectory_msgs)
+
+ament_package()

--- a/moveit_studio_msgs/moveit_pro_controllers_msgs/action/FollowJointTrajectoryWithAdmittance.action
+++ b/moveit_studio_msgs/moveit_pro_controllers_msgs/action/FollowJointTrajectoryWithAdmittance.action
@@ -1,0 +1,49 @@
+# The trajectory for all revolute, continuous or prismatic joints
+trajectory_msgs/JointTrajectory trajectory
+
+# Tolerances applied to the joints as the trajectory is executed.
+# If the measured joint values fall outside the tolerances the trajectory
+# goal is aborted with 'error_code' set to PATH_TOLERANCE_VIOLATED.
+# If empty, default tolerances from configs will be used.
+float64[] path_tolerance
+
+# To report success, the joints must be within 'goal_tolerance' of the
+# final trajectory value at the end of the trajectory time.
+# If the joints are not within 'goal_tolerance' after the trajectory finish
+# time, the goal aborts with error_code set to GOAL_TOLERANCE_VIOLATED.
+# If empty, default tolerances from configs will be used.
+float64[] goal_tolerance
+
+# The absolute force or torque threshold value for each Cartesian axis at which
+# the controller will stop executing if exceeded.
+# If the absolute value of a measured FTS value exceeds the corresponding
+# threshold, the trajectory goal is aborted with 'error_code' set to
+# FORCE_TORQUE_THRESHOLD_EXCEEDED.
+# If empty, default threshold values from configs will be used.
+float64[] absolute_force_torque_threshold
+
+# "Joint Trajectory with Admittance Controller" control parameters.
+# These include stiffness, damping, path tolerances, etc.
+moveit_pro_controllers_msgs/AdmittanceParameters admittance_parameters
+
+---
+int32 error_code
+int32 SUCCESSFUL = 0
+int32 INVALID_GOAL = -1
+int32 INVALID_JOINTS = -2
+int32 OLD_HEADER_TIMESTAMP = -3
+int32 PATH_TOLERANCE_VIOLATED = -4
+int32 GOAL_TOLERANCE_VIOLATED = -5
+int32 ADMITTANCE_ERROR = -6
+int32 FORCE_TORQUE_THRESHOLD_EXCEEDED = -7
+
+# Human readable description of the error code. Contains complementary
+# information that is especially useful when execution fails.
+string error_message
+
+---
+std_msgs/Header header
+string[] joint_names
+trajectory_msgs/JointTrajectoryPoint desired
+trajectory_msgs/JointTrajectoryPoint actual
+trajectory_msgs/JointTrajectoryPoint error

--- a/moveit_studio_msgs/moveit_pro_controllers_msgs/msg/AdmittanceParameters.msg
+++ b/moveit_studio_msgs/moveit_pro_controllers_msgs/msg/AdmittanceParameters.msg
@@ -1,0 +1,11 @@
+# Admittance parameters.
+# These are the parameters of a mass-spring-damper model that determines
+# the admittance behavior on each of the Cartesian axes.
+# Use carefully. Certain choices may lead to unstable behavior.
+float64[] mass
+float64[] stiffness
+float64[] damping
+float64 joint_damping
+
+geometry_msgs/Pose ee_pose_control   # Control frame w.r.t. end-effector frame.
+bool[] selected_axes                 # Axes in the control frame to control with admittance.

--- a/moveit_studio_msgs/moveit_pro_controllers_msgs/msg/CartesianSelectionVector.msg
+++ b/moveit_studio_msgs/moveit_pro_controllers_msgs/msg/CartesianSelectionVector.msg
@@ -1,0 +1,11 @@
+# Message for specifying enabled / disabled Cartesian axes.
+
+# Translational X, Y, Z axes.
+bool x
+bool y
+bool z
+
+# Rotational X, Y, Z axes.
+bool rx
+bool ry
+bool rz

--- a/moveit_studio_msgs/moveit_pro_controllers_msgs/msg/VelocityForceCommand.msg
+++ b/moveit_studio_msgs/moveit_pro_controllers_msgs/msg/VelocityForceCommand.msg
@@ -1,0 +1,24 @@
+# The timestamp in the header is used to determine the age of the command.
+# Commands older than the configured timeout will be rejected.
+std_msgs/Header header
+
+# Cartesian axes to control with velocity vs. force.
+# A value of 'false' disables control of that axis, whereas a value of 'true' enables control.
+# By default (empty), no axes will be controlled. Therefore the user must set at least one axis to control.
+# These are updated once at the beginning of each stream of commands, i.e. they won't take effect if modified
+# during execution.
+moveit_pro_controllers_msgs/CartesianSelectionVector velocity_controlled_axes
+moveit_pro_controllers_msgs/CartesianSelectionVector force_controlled_axes
+
+# Gain to use in force-controlled axes.
+# Multiplier on the force error to determine Cartesian velocity in the force-controlled axes.
+# velocity_on_force_axis = wrench_gain * (wrench_desired - wrench_actual).
+# The gain is updated once at the beginning of each stream of commands, i.e. it won't take effect if modified during
+# execution.
+# Needs to be set, otherwise it will default to 0.0 (no motion).
+float64 wrench_gain
+
+# Desired twist (in the velocity-controlled axes) and wrench (in the force-controlled axes).
+# These can be modified at any time, and the controller will do its best to achieve them.
+geometry_msgs/Twist twist
+geometry_msgs/Wrench wrench

--- a/moveit_studio_msgs/moveit_pro_controllers_msgs/package.xml
+++ b/moveit_studio_msgs/moveit_pro_controllers_msgs/package.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>moveit_pro_controllers_msgs</name>
+  <version>6.1.0</version>
+  <description>Messages used by moveit_pro_controllers</description>
+  <maintainer email="david.yackzan@picknik.ai">David Yackzan</maintainer>
+  <maintainer email="mario.prats@picknik.ai">Mario Prats</maintainer>
+  <maintainer email="paul.gesel@picknik.ai">Paul Gesel</maintainer>
+
+  <license>Proprietary</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>rosidl_default_generators</build_depend>
+
+  <build_depend>action_msgs</build_depend>
+  <build_depend>builtin_interfaces</build_depend>
+  <build_depend>control_msgs</build_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>trajectory_msgs</build_depend>
+
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/moveit_studio_msgs/moveit_pro_controllers_msgs/srv/ConfigureVelocityForceController.srv
+++ b/moveit_studio_msgs/moveit_pro_controllers_msgs/srv/ConfigureVelocityForceController.srv
@@ -1,0 +1,25 @@
+# Interface for configuring a velocity/force controller.
+# The configuration service will first load the configuration from the parameter server, and then override the fields
+# that are present in this request.
+# An empty request will reset the configuration to the default values (or those present in the parameter server).
+
+# Cartesian velocity and acceleration limits.
+bool set_cartesian_velocity_limits
+geometry_msgs/Twist cartesian_velocity_limits
+
+bool set_cartesian_acceleration_limits
+geometry_msgs/Accel cartesian_acceleration_limits
+
+# Joint velocity and acceleration limits.
+bool set_joint_velocity_limits
+float64[] joint_velocity_limits
+
+bool set_joint_acceleration_limits
+float64[] joint_acceleration_limits
+
+---
+# True if the configuration was successfully set.
+bool success
+
+# Error message if success is false.
+string error_message


### PR DESCRIPTION
First half for https://github.com/PickNikRobotics/moveit_studio/issues/8120.
Just copies the `moveit_pro_controller_msgs` that we have in MP here into the sdk repo so that the message definitions are more accessible.
A follow-up will remove them from MP and update the submodule
