### PR TITLE
Exit when objective is done befire timeout

### DIFF
--- a/moveit_studio_py/examples/start_stop_async.py
+++ b/moveit_studio_py/examples/start_stop_async.py
@@ -38,6 +38,7 @@ import time
 from moveit_msgs.msg import MoveItErrorCodes
 from moveit_studio_py.objective_manager import ObjectiveManager
 
+done = False
 
 def done_cb(future: rclpy.task.Future) -> None:
     """
@@ -51,6 +52,8 @@ def done_cb(future: rclpy.task.Future) -> None:
         print("Objective executed successfully!")
     else:
         print(f"MoveItErrorCode Value: {result.error_code.val}")
+    global done
+    done = True
 
 
 def main():
@@ -74,14 +77,18 @@ def main():
     objective_manager = ObjectiveManager()
 
     print(f"Starting {args.objective_name}.")
+    global done
+    done = False
     objective_manager.start_objective(
         args.objective_name, blocking=False, async_callback=done_cb
     )
+    cancel_time = time.time() + args.wait_time
+    while not done and time.time() < cancel_time: 
+        time.sleep(1)
 
-    time.sleep(args.wait_time)
-
-    print(f"Stopping {args.objective_name}.")
-    objective_manager.stop_objective()
+    if not done:
+        print(f"Stopping {args.objective_name}.")
+        objective_manager.stop_objective()
 
     rclpy.shutdown()
 

--- a/moveit_studio_py/examples/start_stop_async.py
+++ b/moveit_studio_py/examples/start_stop_async.py
@@ -40,6 +40,7 @@ from moveit_studio_py.objective_manager import ObjectiveManager
 
 done = False
 
+
 def done_cb(future: rclpy.task.Future) -> None:
     """
     Callback that is triggered when an Objective that was started asynchronously is done executing.
@@ -83,7 +84,7 @@ def main():
         args.objective_name, blocking=False, async_callback=done_cb
     )
     cancel_time = time.time() + args.wait_time
-    while not done and time.time() < cancel_time: 
+    while not done and time.time() < cancel_time:
         time.sleep(1)
 
     if not done:


### PR DESCRIPTION
Fixes #68 

Instead of sleeping for the entire timeout duration, it sleeps for 1 second at a time and checks if the objective is done. If the objective is done, it exits. If it reaches the timeout, then it cancels the objective as before. 
```
root@mkhansen-ThinkPad-T15-Gen-2i:/opt/moveit_studio_sdk_ws# ros2 run moveit_studio_py start_stop_async.py "3 Waypoints Pick and Place" 10
Starting 3 Waypoints Pick and Place.
Stopping 3 Waypoints Pick and Place.
Objective STOPPED by user
root@mkhansen-ThinkPad-T15-Gen-2i:/opt/moveit_studio_sdk_ws# ros2 run moveit_studio_py start_stop_async.py "Open Gripper" 10
Starting Open Gripper.
Objective executed successfully!
```