### PR TITLE
adds a control frame to the vfc command message

### DIFF
--- a/moveit_studio_msgs/moveit_pro_controllers_msgs/msg/VelocityForceCommand.msg
+++ b/moveit_studio_msgs/moveit_pro_controllers_msgs/msg/VelocityForceCommand.msg
@@ -2,11 +2,18 @@
 # Commands older than the configured timeout will be rejected.
 std_msgs/Header header
 
+# The frame in which the command is given.
+# Relative to the end-effector frame defined in the configs. Defaults to identity.
+# This can be used to specify an offset with respect to the end-effector frame. Global control frames are not
+# yet supported.
+geometry_msgs/Transform control_frame
+
 # Cartesian axes to control with velocity vs. force.
 # A value of 'false' disables control of that axis, whereas a value of 'true' enables control.
 # By default (empty), no axes will be controlled. Therefore the user must set at least one axis to control.
 # These are updated once at the beginning of each stream of commands, i.e. they won't take effect if modified
 # during execution.
+# Given in the control frame (see 'control_frame' above).
 moveit_pro_controllers_msgs/CartesianSelectionVector velocity_controlled_axes
 moveit_pro_controllers_msgs/CartesianSelectionVector force_controlled_axes
 
@@ -20,6 +27,7 @@ float64 wrench_gain
 
 # Desired twist (in the velocity-controlled axes) and wrench (in the force-controlled axes).
 # These can be modified at any time, and the controller will do its best to achieve them.
+# Given in the control frame.
 geometry_msgs/Twist twist
 geometry_msgs/Wrench wrench
 


### PR DESCRIPTION
Work towards https://github.com/PickNikRobotics/PhilipsSOW1/issues/58
Adds a field to the VFC message to be able to specify a control frame, relative to the kinematic chain tip link.