### PR TITLE
add planning groups and controllers as feedback

### DIFF
--- a/moveit_studio_msgs/moveit_studio_sdk_msgs/action/DoTeleoperate.action
+++ b/moveit_studio_msgs/moveit_studio_sdk_msgs/action/DoTeleoperate.action
@@ -27,3 +27,8 @@ string reason
 
 # The current teleoperation mode
 TeleoperationMode current_mode
+
+# The selected planning groups and associated controllers
+# The UI must fill these fields with the planning groups that need to be teleoperated.
+string[] planning_groups
+string[] controllers


### PR DESCRIPTION
First part of https://github.com/PickNikRobotics/moveit_pro/issues/11217
Adds `planning_groups` and `controllers` as feedback fields, to be filled in by the UI with the planning groups selected by the user for teleoperation