### PR TITLE
Change objective status to an enum in ObjectiveServerStatus.msg

### DIFF
--- a/moveit_studio_msgs/moveit_studio_agent_msgs/msg/ObjectiveServerStatus.msg
+++ b/moveit_studio_msgs/moveit_studio_agent_msgs/msg/ObjectiveServerStatus.msg
@@ -1,8 +1,17 @@
-# Heartbeat timestamps of the Objective Server node
+# Heartbeat timestamps of the Objective Server node.
 builtin_interfaces/Time process_timestamp
 builtin_interfaces/Time ros_timestamp
 
-# Name and status descriptor of the current objective tree
-# See StatusTree::NodeStatus for valid objective_status values
+# Name and status descriptor of the current objective tree.
 string objective_name
-string objective_status
+
+# Possible objective_status values.
+# This corresponds with StatusTree::NodeStatus in the objective server.
+int8 OBJECTIVE_STATUS_UNKNOWN = 0
+int8 OBJECTIVE_STATUS_IDLE = 1
+int8 OBJECTIVE_STATUS_RUNNING = 2
+int8 OBJECTIVE_STATUS_SUCCESS = 3
+int8 OBJECTIVE_STATUS_FAILURE = 4
+
+# The status of the objective.
+int8 objective_status


### PR DESCRIPTION
The style is a bit different than other enums in this repo but this way should remove some ambiguity if this message is ever extended upon.