### PR TITLE
add end-effector info to PlanningGroup msg

### DIFF
--- a/moveit_studio_msgs/moveit_studio_agent_msgs/CMakeLists.txt
+++ b/moveit_studio_msgs/moveit_studio_agent_msgs/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(std_msgs REQUIRED)
 set(msg_files
   "msg/AgentInfo.msg"
   "msg/ClientInfo.msg"
+  "msg/EndEffector.msg"
   "msg/Event.msg"
   "msg/FaultStatus.msg"
   "msg/Json.msg"

--- a/moveit_studio_msgs/moveit_studio_agent_msgs/msg/EndEffector.msg
+++ b/moveit_studio_msgs/moveit_studio_agent_msgs/msg/EndEffector.msg
@@ -1,0 +1,11 @@
+# The name of the end-effector, as defined in the SRDF.
+string name
+
+# The name of the group that contains the links and joints that make up the end-effector.
+string group
+
+# The name of the parent group this end-effector is attached to.
+string parent_group
+
+# The name of the link in the parent group this end-effector is attached to.
+string parent_link

--- a/moveit_studio_msgs/moveit_studio_agent_msgs/msg/PlanningGroup.msg
+++ b/moveit_studio_msgs/moveit_studio_agent_msgs/msg/PlanningGroup.msg
@@ -1,8 +1,7 @@
 # Name of the planning group, as defined in the SRDF.
 string name
 
-# Indicates if an IK solver is defined for this group
-# and thus, if it can be used by servo
+# Indicates if an IK solver is defined for this group.
 bool has_ik_solver
 
 # Base frame of the planning group.
@@ -12,3 +11,6 @@ string base_frame
 # Tip frames of the planning group.
 # Only filled in if the group has a kinematics solver.
 string[] tip_frames
+
+# The end-effectors connected to this planning group.
+EndEffector[] end_effectors


### PR DESCRIPTION
Adds end-effector information to the PlanningGroup message.
This is in preparation for plumbing this information up to the UI