### PR TITLE
Add tip_links to UI teleoperate feedback

### DIFF
--- a/moveit_studio_msgs/moveit_studio_sdk_msgs/action/DoTeleoperate.action
+++ b/moveit_studio_msgs/moveit_studio_sdk_msgs/action/DoTeleoperate.action
@@ -28,7 +28,8 @@ string reason
 # The current teleoperation mode
 TeleoperationMode current_mode
 
-# The selected planning groups and associated controllers
+# The selected planning groups, associated controllers and tip links.
 # The UI must fill these fields with the planning groups that need to be teleoperated.
 string[] planning_groups
 string[] controllers
+string[] tip_links


### PR DESCRIPTION
This is so that the frontend can communicate to the backend, during teleop, which tip link is being tele-operated.
For now to be filled in with just the last link of the active planning group.

This is required because WaitForUserTrajectoryApproval (used in IMarker teleop) now takes a list of tip links to visualize the Cartesian path. Rather than hardcoding it, we can take it from the frontend, so that this is prepared for the future.