### PR TITLE
Add GOAL_ABORTED_DUE_TO_STITCHING enum result

### DIFF
--- a/moveit_studio_msgs/moveit_pro_controllers_msgs/action/FollowJointTrajectoryWithAdmittance.action
+++ b/moveit_studio_msgs/moveit_pro_controllers_msgs/action/FollowJointTrajectoryWithAdmittance.action
@@ -36,6 +36,7 @@ int32 PATH_TOLERANCE_VIOLATED = -4
 int32 GOAL_TOLERANCE_VIOLATED = -5
 int32 ADMITTANCE_ERROR = -6
 int32 FORCE_TORQUE_THRESHOLD_EXCEEDED = -7
+int32 GOAL_ABORTED_DUE_TO_STITCHING = -8
 
 # Human readable description of the error code. Contains complementary
 # information that is especially useful when execution fails.


### PR DESCRIPTION
Add GOAL_ABORTED_DUE_TO_STITCHING enum result to indicate the goal was aborted due to stitching